### PR TITLE
v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.0.1
+
+- Added `AnyNode` and `NoneNode`.
+- `Graph`:
+  - Added `populate` and `populateAsync`.
+  - Added `walkOutputsFrom` and `walkInputsFrom`.
+  - Added `rootValues`, `valuesToNodes`.
+- `Node`:
+  - Added field `attachment`.
+- New `GraphWalker`.
+
+- Removed `ascii_art_tree` dependency:
+  - Package `ascii_art_tree 1.0.6` now uses `graph_explorer` internally (avoid dependency loop).
+      - The `Graph` integration was moved to package `ascii_art_tree` as an extension.
+
 ## 1.0.0
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,22 @@
 - `Graph`:
   - Added `populate` and `populateAsync`.
   - Added `walkOutputsFrom` and `walkInputsFrom`.
+  - Added `walkOutputsOrderFrom` and `walkInputsOrderFrom`.
   - Added `rootValues`, `valuesToNodes`.
+  - Added `getNodes` and `getNodesNullable`.
 - `Node`:
   - Added field `attachment`.
+  - Added `roots`, `sideRoots`, `dependencies`, `missingDependencies`.
+- `IterableNodeExtension`:
+  - Added `merge` and `complement`.
+  - Added `inputsInDepthIntersection`, `sortedByOutputDependency` and `sortedByInputDependency`.
 - New `GraphWalker`.
 
 - Removed `ascii_art_tree` dependency:
   - Package `ascii_art_tree 1.0.6` now uses `graph_explorer` internally (avoid dependency loop).
       - The `Graph` integration was moved to package `ascii_art_tree` as an extension.
+
+- Improved tests coverage (80%+).
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ void main() async {
   graph.node('a').getOrAddOutput('b')
     ..addOutput('c')
     ..addOutput('d');
-
+  
   graph.node('c').addOutput('f');
   graph.node('d').getOrAddOutput('e').addOutput('f');
-
+  
+  graph.node('f').addOutput('x');
+  
   var result = await graph.scanPathsFrom('a', 'f', findAll: true);
-
+  
   print("Paths from `a` to `f`:");
   for (var p in result.paths) {
     var lStr = p.toListOfString();
@@ -45,12 +47,8 @@ void main() async {
 
   var tree = graph.toTree();
 
-  print('\nGraph to Tree:');
+  print('\nGraph to JSON Tree:');
   print(_encodeJsonPretty(tree));
-
-  var asciiArtTree = graph.toASCIIArtTree();
-  print('\nGraph to ASCII Art Tree:');
-  print(asciiArtTree.generate());
 }
 
 String _encodeJsonPretty(dynamic json) =>
@@ -66,32 +64,61 @@ Paths from `a` to `f`:
 Shortest paths:
 - [a, b, c, f]
 
-Graph to Tree:
+Graph to JSON Tree:
 {
   "a": {
     "b": {
       "c": {
-        "f": {}
+        "f": {
+          "x": null
+        }
       },
       "d": {
         "e": {
-          "f": "f"
+          "f": "f"  // This is a reference to the node `f` above.
         }
       }
     }
   }
 }
+```
 
-Graph to ASCII Art Tree:
+## ascii_art_tree
+
+With the package [ascii_art_tree] you can easly generate an ASCII Art Tree of the `Graph` object:
+
+```dart
+import 'package:ascii_art_tree/ascii_art_tree.dart'; // Import extension on `Graph`
+import 'package:graph_explorer/graph_explorer.dart';
+
+void main() {
+  var graph = Graph<String>();
+
+  // Build the graph as
+  // shown in the example above...
+
+  // Build the `ASCIIArtTree`:
+  var asciiArtTree = graph.toASCIIArtTree();
+
+  // Generate the ASCII Art text:
+  var tree = asciiArtTree.generate();
+  print(tree);
+}
+```
+
+Output:
+```text
 a
 └─┬─ b
-  ├─┬─ c
-  │ └──> f
-  └─┬─ d
-    └─┬─ e
-      └──> f ººº
-
+  ├─┬─ d
+  │ └─┬─ e
+  │   └─┬─ f
+  │     └──> x
+  └─┬─ c
+    └─┬─ f ººº
 ```
+
+[ascii_art_tree]: https://pub.dev/packages/ascii_art_tree
 
 ## Features and bugs
 

--- a/example/graph_explorer_example.dart
+++ b/example/graph_explorer_example.dart
@@ -12,6 +12,8 @@ void main() async {
   graph.node('c').addOutput('f');
   graph.node('d').getOrAddOutput('e').addOutput('f');
 
+  graph.node('f').addOutput('x');
+
   var result = await graph.scanPathsFrom('a', 'f', findAll: true);
 
   print("Paths from `a` to `f`:");
@@ -28,7 +30,7 @@ void main() async {
 
   var tree = graph.toTree();
 
-  print('\nGraph to Tree:');
+  print('\nGraph to JSON Tree:');
   print(_encodeJsonPretty(tree));
 }
 
@@ -45,12 +47,14 @@ String _encodeJsonPretty(dynamic json) =>
 // Shortest paths:
 // - [a, b, c, f]
 //
-// Graph to Tree:
+// Graph to JSON Tree:
 // {
 //   "a": {
 //     "b": {
 //       "c": {
-//         "f": null
+//         "f": {
+//           "x": null
+//         }
 //       },
 //       "d": {
 //         "e": {

--- a/example/graph_explorer_example.dart
+++ b/example/graph_explorer_example.dart
@@ -30,10 +30,6 @@ void main() async {
 
   print('\nGraph to Tree:');
   print(_encodeJsonPretty(tree));
-
-  var asciiArtTree = graph.toASCIIArtTree();
-  print('\nGraph to ASCII Art Tree:');
-  print(asciiArtTree.generate());
 }
 
 String _encodeJsonPretty(dynamic json) =>
@@ -54,7 +50,7 @@ String _encodeJsonPretty(dynamic json) =>
 //   "a": {
 //     "b": {
 //       "c": {
-//         "f": {}
+//         "f": null
 //       },
 //       "d": {
 //         "e": {
@@ -64,13 +60,4 @@ String _encodeJsonPretty(dynamic json) =>
 //     }
 //   }
 // }
-//
-// Graph to ASCII Art Tree:
-// a
-// └─┬─ b
-//   ├─┬─ c
-//   │ └──> f
-//   └─┬─ d
-//     └─┬─ e
-//       └──> f ººº
 //

--- a/lib/graph_explorer.dart
+++ b/lib/graph_explorer.dart
@@ -2,3 +2,4 @@
 library graph_explorer;
 
 export 'src/graph_explorer_base.dart';
+export 'src/graph_explorer_walker.dart';

--- a/lib/src/graph_explorer_base.dart
+++ b/lib/src/graph_explorer_base.dart
@@ -7,20 +7,44 @@
 //
 
 import 'dart:async';
-import 'dart:collection';
 
-import 'package:ascii_art_tree/ascii_art_tree.dart';
 import 'package:collection/collection.dart';
+
+import 'graph_explorer_walker.dart';
 
 /// A [Node] matcher, used by [GraphScanner].
 abstract class NodeMatcher<T> {
   NodeMatcher();
+
+  factory NodeMatcher.eq(List<T> targets) {
+    return targets.length == 1
+        ? NodeEquals(targets.first)
+        : MultipleNodesEquals(targets);
+  }
 
   /// Returns `true` if [node] matches.
   bool matchesNode(Node<T> node) => matchesValue(node.value);
 
   /// Returns `true` if [value] matches.
   bool matchesValue(T value);
+}
+
+/// A [Node] matcher that matches ANY node (always returns `true` for a match).
+class AnyNode<T> extends NodeMatcher<T> {
+  @override
+  bool matchesNode(Node<T> node) => true;
+
+  @override
+  bool matchesValue(T value) => true;
+}
+
+/// A [Node] matcher that always returns `false` and never matches a node.
+class NoneNode<T> extends NodeMatcher<T> {
+  @override
+  bool matchesNode(Node<T> node) => false;
+
+  @override
+  bool matchesValue(T value) => false;
 }
 
 /// A [Node] matcher that uses object equality (`==` operator).
@@ -146,58 +170,64 @@ class GraphScanner<T> {
       {Graph<T>? graph, NodesProvider<T>? outputsProvider}) async {
     var initTime = DateTime.now();
 
-    if (graph == null) {
-      graph = Graph<T>();
-    } else {
-      graph.reset();
-    }
+    bool? processTarget(GraphNodeStep<T> step) {
+      var node = step.node;
 
-    var populate = true;
-    if (outputsProvider == null) {
-      outputsProvider = (Graph<T> graph, Node<T> node) => node._outputs;
-      populate = false;
-    }
-
-    final scanQueue = ListQueue<Node<T>>(fromMany.length * 2);
-
-    for (var fromNode in fromMany) {
-      scanQueue.add(graph.node(fromNode));
-    }
-
-    final scannedNodes = <Node<T>>{};
-
-    SCAN:
-    while (scanQueue.isNotEmpty) {
-      var node = scanQueue.removeFirst();
-
-      var outputs = await outputsProvider(graph, node);
-
-      for (var output in outputs) {
-        var checkNode = true;
-        if (populate) {
-          checkNode = output._addInputNode(node) != null;
-          node._addOutputNode(output);
-        } else {
-          output._addInputNode(node);
-        }
-
-        // Probably a new node:
-        if (checkNode) {
-          // Found a target:
-          if (targetMatcher.matchesNode(output)) {
-            output.markAsTarget();
-
-            if (!findAll) {
-              break SCAN;
-            }
-          }
-
-          // New node to scan:
-          if (scannedNodes.add(output)) {
-            scanQueue.addLast(output);
-          }
+      if (targetMatcher.matchesNode(node)) {
+        node.markAsTarget();
+        if (!findAll) {
+          return true;
         }
       }
+      return null;
+    }
+
+    if (graph == null) {
+      graph = Graph<T>();
+
+      if (outputsProvider == null) {
+        return GraphScanResult(graph, fromMany, targetMatcher, [],
+            findAll: findAll,
+            time: Duration.zero,
+            resolvePathsTime: Duration.zero);
+      }
+
+      FutureOr<Iterable<T>> nodeOutputsProvider(
+          GraphNodeStep<T> step, T nodeValue) {
+        var l = outputsProvider(graph!, graph.node(nodeValue));
+
+        if (l is Future<List<Node<T>>>) {
+          return l.then((l) => l.toIterableOfValues());
+        } else {
+          return l.toIterableOfValues();
+        }
+      }
+
+      await graph.populateAsync(fromMany,
+          outputsProvider: nodeOutputsProvider, process: processTarget);
+    } else {
+      if (graph.isEmpty && outputsProvider == null) {
+        return GraphScanResult(graph, fromMany, targetMatcher, [],
+            findAll: findAll,
+            time: Duration.zero,
+            resolvePathsTime: Duration.zero);
+      }
+
+      graph.reset();
+
+      final nodeOutputsProvider = outputsProvider != null
+          ? (GraphNodeStep<T> step, Node<T> node) =>
+              outputsProvider(graph!, node)
+          : (GraphNodeStep<T> step, Node<T> node) => node._outputs;
+
+      await GraphWalker<T>(
+        maxExpansion: 3,
+        bfs: true,
+      ).walkByNodesAsync<bool>(
+        graph.valuesToNodes(fromMany, createNodes: true),
+        process: processTarget,
+        outputsProvider: nodeOutputsProvider,
+      );
     }
 
     var pathsInitTime = DateTime.now();
@@ -278,38 +308,61 @@ class Graph<T> implements NodeIO<T> {
 
   /// Creates a [Graph] from [json].
   factory Graph.fromJson(Map<String, dynamic> json,
-      {T Function(String key)? nodeValueMapper}) {
+      {T Function(GraphStep<T>? previousStep, String key)? nodeValueMapper}) {
     if (nodeValueMapper == null) {
       if (T == String) {
-        nodeValueMapper = (k) => k.toString() as T;
+        nodeValueMapper = (s, k) => k.toString() as T;
       } else {
-        nodeValueMapper = (k) => k as T;
+        nodeValueMapper = (s, k) => k as T;
       }
     }
 
-    final g = Graph<T>();
+    final graph = Graph<T>();
 
-    final queue = ListQueue<List>()..add([g, json]);
+    graph.populate(
+      json.keys.map((k) => nodeValueMapper!(null, k)),
+      nodeProvider: (step, nodeValue) {
+        var node = graph.node(nodeValue);
 
-    while (queue.isNotEmpty) {
-      var entry = queue.removeFirst();
+        var parentNode = graph.getNode(step.parentValue);
+        Map parentJsonNode = parentNode?.attachment ?? json;
+        var jsonNode = parentJsonNode[nodeValue];
 
-      var node = entry[0] as NodeIO<T>;
-      var map = entry[1] as Map<String, dynamic>;
+        var nodeAttachment = node.attachment;
+        if (nodeAttachment == null) {
+          if (jsonNode != null && (jsonNode is! Map && jsonNode is! String)) {
+            throw StateError("Invalid node type> $nodeValue: $jsonNode");
+          }
 
-      for (var e in map.entries) {
-        var nodeValue = nodeValueMapper(e.key);
-
-        var child = node.addOutput(nodeValue);
-        var childNodes = e.value;
-
-        if (child != null && childNodes is Map<String, dynamic>) {
-          queue.add([child, e.value]);
+          node.attachment = jsonNode;
+        } else if (!identical(jsonNode, nodeAttachment)) {
+          if (jsonNode is Map) {
+            if (nodeAttachment is Map) {
+              nodeAttachment.addAll(jsonNode);
+            } else if (nodeAttachment is String) {
+              node.attachment = jsonNode;
+            }
+          } else if (jsonNode is String) {
+            if (jsonNode != nodeValue.toString()) {
+              throw StateError(
+                  "Invalid node reference: $nodeValue -> $jsonNode");
+            }
+          } else {
+            throw StateError(
+                "Invalid node type (graph)> $nodeValue: $jsonNode");
+          }
         }
-      }
-    }
 
-    return g;
+        return node;
+      },
+      outputsProvider: (step, nodeValue) {
+        var jsonNode = graph.getNode(nodeValue)?.attachment;
+        if (jsonNode is! Map || jsonNode.isEmpty) return null;
+        return jsonNode.keys.map((k) => nodeValueMapper!(step, k));
+      },
+    );
+
+    return graph;
   }
 
   /// Returns all the leaves of this graph (nodes without outputs)
@@ -348,10 +401,26 @@ class Graph<T> implements NodeIO<T> {
   Node<T> node(T value) => _allNodes[value] ??= Node(value, graph: this);
 
   /// Returns a [Node] with [value] or `null` if not present.
-  Node<T>? getNode(T value) => _allNodes[value];
+  Node<T>? getNode(T? value) {
+    if (value == null) return null;
+    return _allNodes[value];
+  }
 
   /// Alias to [getNode].
   Node<T>? operator [](T value) => getNode(value);
+
+  /// Maps [values] to [Node]s in this graph.
+  /// - If [createNodes] is `false` will throw a [StateError] if the node is not present in this graph.
+  Iterable<Node<T>> valuesToNodes(Iterable<T> values,
+      {bool createNodes = false}) {
+    if (createNodes) {
+      return values.map((value) => node(value));
+    } else {
+      return values.map((value) =>
+          getNode(value) ??
+          (throw StateError("Can't find node with value: $value")));
+    }
+  }
 
   /// Returns a [Node] with [value] or creates it as always root.
   Node<T> root(T value) {
@@ -363,11 +432,15 @@ class Graph<T> implements NodeIO<T> {
   List<Node<T>> get roots =>
       _allNodes.values.where((e) => e.isRoot).toList(growable: false);
 
+  /// Returns a list of root values (without inputs).
+  List<T> get rootValues => roots.map((e) => e.value).toList(growable: false);
+
   /// Returns a list of nodes market as targets.
   List<Node<T>> get targets =>
       _allNodes.values.where((e) => e.isTarget).toList(growable: false);
 
-  /// Resets this graph for a path scan.
+  /// Resets this graph and all its [Node]s for a path scan.
+  /// See [Node.reset].
   @override
   void reset() {
     for (var node in _allNodes.values) {
@@ -387,99 +460,20 @@ class Graph<T> implements NodeIO<T> {
   }
 
   /// Returns a [Map] representation of this graph.
-  Map<K, dynamic> toTree<K>({K Function(T value)? keyCast}) {
+  Map<K, dynamic> toTree<K>({K Function(T value)? keyCast, bool bfs = false}) {
     var rootValues = roots.map((e) => e.value).toList();
-    return toTreeFrom<K>(rootValues, keyCast: keyCast);
+    return toTreeFrom<K>(rootValues, keyCast: keyCast, bfs: bfs);
   }
 
   /// Returns a [Map] representation of this graph from [roots].
-  Map<K, dynamic> toTreeFrom<K>(List<T> roots, {K Function(T value)? keyCast}) {
-    if (keyCast == null) {
-      if (K == String) {
-        keyCast = (v) => v.toString() as K;
-      } else if (K == Node || K == <Node<T>>[].genericType) {
-        keyCast = (v) => getNode(v) as K;
-      } else {
-        keyCast = (v) => v as K;
-      }
-    }
-
-    Map<K, dynamic> Function() createNode = K == dynamic
-        ? () => (<T, dynamic>{} as Map<K, dynamic>)
-        : () => <K, dynamic>{};
-
-    Map<K, Map<K, dynamic>> allTreeNodes = K == dynamic
-        ? (<T, Map<T, dynamic>>{} as Map<K, Map<K, dynamic>>)
-        : <K, Map<K, dynamic>>{};
-
-    Map<K, dynamic> tree =
-        K == dynamic ? (<T, dynamic>{} as Map<K, dynamic>) : <K, dynamic>{};
-
-    var processedNode = <Node<T>>{};
-    var queue = ListQueue<Node<T>>();
-
-    for (var root in roots) {
-      var rootNode = getNode(root) ??
-          (throw ArgumentError("Root not present in graph: $root"));
-
-      assert(rootNode.value == root);
-
-      processedNode.add(rootNode);
-      queue.add(rootNode);
-
-      var rootK = keyCast(root);
-
-      tree[rootK] ??= allTreeNodes[rootK] ??= createNode();
-    }
-
-    while (queue.isNotEmpty) {
-      var node = queue.removeFirst();
-
-      var nodeK = keyCast(node.value);
-
-      var treeNode = allTreeNodes[nodeK] ??= createNode();
-
-      for (var child in node._outputs) {
-        var childValue = child.value;
-        var childK = keyCast(childValue);
-
-        dynamic ref;
-
-        var childTreeNode = allTreeNodes[childValue];
-        if (childTreeNode == null) {
-          childTreeNode = allTreeNodes[childK] = createNode();
-          ref = childTreeNode;
-        } else {
-          ref = childValue;
-        }
-
-        treeNode[childK] ??= ref;
-
-        if (processedNode.add(child)) {
-          queue.add(child);
-        }
-      }
-    }
-
-    return tree;
-  }
+  Map<K, dynamic> toTreeFrom<K>(List<T> roots,
+          {K Function(T value)? keyCast, bool bfs = false}) =>
+      GraphWalker<T>().toTreeFrom<K>(roots,
+          nodeProvider: (s, v) => getNode(v),
+          outputsProvider: (s, n) => n._outputs);
 
   /// Returns a JSON representation of this graph.
   Map<String, dynamic> toJson() => toTree<String>();
-
-  /// Returns an [ASCIIArtTree] of this graph.
-  ASCIIArtTree toASCIIArtTree(
-      {String? stripPrefix,
-      String? stripSuffix,
-      ASCIIArtTreeStyle style = ASCIIArtTreeStyle.elegant,
-      bool allowGraphs = true}) {
-    var tree = toTree<String>();
-    return ASCIIArtTree(tree,
-        stripPrefix: stripPrefix,
-        stripSuffix: stripSuffix,
-        style: style,
-        allowGraphs: allowGraphs);
-  }
 
   /// Scans and returns the paths from [root] to [target].
   Future<GraphScanResult<T>> scanPathsFrom(T root, T target,
@@ -493,7 +487,7 @@ class Graph<T> implements NodeIO<T> {
       {bool? findAll}) {
     findAll ??= roots.length > 1 || targets.length > 1;
     var scanner = GraphScanner<T>(findAll: findAll);
-    return scanner.scanPathsFromMany(roots, MultipleNodesEquals(targets),
+    return scanner.scanPathsFromMany(roots, NodeMatcher.eq(targets),
         graph: this);
   }
 
@@ -543,6 +537,131 @@ class Graph<T> implements NodeIO<T> {
     var paths = await this.allPaths;
     return paths.shortestPaths();
   }
+
+  /// Populates this graph with [entries].
+  /// - [inputsProvider]: provides the inputs of an entry.
+  /// - [outputsProvider]: provides the outputs of an entry.
+  void populate(
+    Iterable<T> entries, {
+    GraphWalkNodeProvider<T>? nodeProvider,
+    GraphWalkOutputsProvider<T>? inputsProvider,
+    GraphWalkOutputsProvider<T>? outputsProvider,
+    bool? Function(GraphNodeStep<T> step, Node<T> node)? process,
+    bool bfs = false,
+  }) {
+    nodeProvider ??= (s, e) => this.node(e);
+    inputsProvider ??= (s, e) => [];
+    outputsProvider ??= (s, e) => [];
+
+    GraphWalker<T>(
+      maxExpansion: 3,
+    ).walk<bool>(
+      entries,
+      nodeProvider: nodeProvider,
+      outputsProvider: outputsProvider,
+      process: (step) {
+        var node = step.node;
+        var nodeValue = node.value;
+
+        var outputs = outputsProvider!(step, nodeValue) ?? [];
+        for (var child in outputs) {
+          node.addOutput(child);
+        }
+
+        var inputs = inputsProvider!(step, nodeValue) ?? [];
+        for (var dep in inputs) {
+          node.addInput(dep);
+        }
+
+        if (process != null) {
+          var stop = process(step, node);
+          if (stop != null && stop) {
+            return true;
+          }
+        }
+
+        return null;
+      },
+    );
+  }
+
+  Future<void> populateAsync(
+    Iterable<T> entries, {
+    GraphWalkNodeProvider<T>? nodeProvider,
+    GraphWalkOutputsProviderAsync<T>? inputsProvider,
+    GraphWalkOutputsProviderAsync<T>? outputsProvider,
+    GraphWalkNodeProcessor<T>? process,
+    bool bfs = false,
+  }) async {
+    nodeProvider ??= (s, e) => this.node(e);
+    inputsProvider ??= (s, e) => [];
+    outputsProvider ??= (s, e) => [];
+
+    await GraphWalker<T>().walkAsync<bool>(
+      entries,
+      nodeProvider: nodeProvider,
+      outputsProvider: outputsProvider,
+      process: (step) async {
+        var node = step.node;
+        var nodeValue = node.value;
+
+        var outputs = await outputsProvider!(step, nodeValue) ?? [];
+        for (var child in outputs) {
+          node.addOutput(child);
+        }
+
+        var inputs = await inputsProvider!(step, nodeValue) ?? [];
+        for (var dep in inputs) {
+          node.addInput(dep);
+        }
+
+        if (process == null) {
+          return null;
+        }
+
+        var stop = await process(step);
+        return stop;
+      },
+    );
+  }
+
+  /// Walk the graph nodes outputs starting [from] and stopping at [stopMatcher] (if provided).
+  void walkOutputsFrom(
+    Iterable<T> from,
+    GraphWalkNodeProcessor<T> process, {
+    NodeMatcher<T>? stopMatcher,
+    bool processRoots = true,
+    int maxExpansion = 1,
+    bool bfs = false,
+  }) =>
+      GraphWalker<T>(
+        stopMatcher: stopMatcher,
+        processRoots: processRoots,
+        bfs: bfs,
+        maxExpansion: maxExpansion,
+      ).walkByNodes<bool>(
+        valuesToNodes(from),
+        process: process,
+        outputsProvider: (step, node) => node._outputs,
+      );
+
+  /// Walk the graph nodes inputs starting [from] and stopping at [stopMatcher] (if provided).
+  void walkInputsFrom(
+    Iterable<T> from,
+    GraphWalkNodeProcessor<T> process, {
+    NodeMatcher<T>? stopMatcher,
+    bool processRoots = true,
+    bool bfs = false,
+  }) =>
+      GraphWalker<T>(
+        stopMatcher: stopMatcher,
+        processRoots: processRoots,
+        bfs: bfs,
+      ).walkByNodes<bool>(
+        valuesToNodes(from),
+        process: process,
+        outputsProvider: (step, node) => node._inputs,
+      );
 }
 
 /// A [Graph] [Node].
@@ -587,6 +706,10 @@ class Node<T> extends NodeIO<T> {
     _graph = null;
     g?.dispose();
   }
+
+  /// Temporary attachment to associate with this node.
+  /// See [reset] and [Graph.reset].
+  dynamic attachment;
 
   bool _target = false;
 
@@ -791,28 +914,85 @@ class Node<T> extends NodeIO<T> {
     return node;
   }
 
+  /// Returns `true` if [targetValue] is an input of this node.
+  bool isInput(T targetValue) => isInputNode(_resolveNode(targetValue));
+
   /// Returns `true` if [target] is an input of this node.
-  bool isInput(Node target) {
-    if (this == target) return true;
+  bool isInputNode(Node<T> target) {
+    if (this == target) return false;
 
-    var processedNode = <Node<T>>{this};
-    var queue = ListQueue<Node<T>>()..add(this);
+    return GraphWalker<T>(
+          stopMatcher: NodeEquals<T>(target.value),
+        ).walkByNodes<bool>(
+          [this],
+          outputsProvider: (step, node) => node._inputs,
+          process: (step) => step.node == target,
+        ) ??
+        false;
+  }
 
-    while (queue.isNotEmpty) {
-      var node = queue.removeFirst();
+  /// Returns `true` if [targetValue] is an output of this node.
+  bool isOutput(T targetValue) => isOutputNode(_resolveNode(targetValue));
 
-      for (var p in node._inputs) {
-        if (p == target) {
-          return true;
-        }
+  /// Returns `true` if [target] is an output of this node.
+  bool isOutputNode(Node<T> target) {
+    if (this == target) return false;
 
-        if (processedNode.add(p)) {
-          queue.add(p);
-        }
-      }
-    }
+    return GraphWalker(
+      stopMatcher: NodeEquals<T>(target.value),
+    ).walkByNodes(
+      [this],
+      outputsProvider: (step, node) => node._outputs,
+      process: (step) => step.node == target,
+    );
+  }
 
-    return false;
+  /// Returns all the [outputs] in depth, scanning all the [outputs] of [outputs].
+  List<Node<T>> outputsInDepth({bool bfs = false}) {
+    final allNodes = <Node<T>>[];
+
+    GraphWalker<T>(
+      processRoots: false,
+      bfs: bfs,
+    ).walkByNodes<bool>(
+      [this],
+      outputsProvider: (step, node) => node._outputs,
+      process: (step) => allNodes.add(step.node),
+    );
+
+    return allNodes;
+  }
+
+  /// Returns all the [inputs] in depth, scanning all the [inputs] of [inputs].
+  List<Node<T>> inputsInDepth({bool bfs = false}) {
+    final allNodes = <Node<T>>[];
+
+    GraphWalker<T>(
+      processRoots: false,
+      bfs: bfs,
+    ).walkByNodes<bool>(
+      [this],
+      outputsProvider: (step, node) => node._inputs,
+      process: (step) => allNodes.add(step.node),
+    );
+
+    return allNodes;
+  }
+
+  List<Node<T>> outputsInDepthIntersection(Node<T>? other) {
+    var l2 = other?.outputsInDepth();
+    if (l2 == null || l2.isEmpty) return [];
+
+    var l1 = outputsInDepth();
+    return l1.intersection(l2);
+  }
+
+  List<Node<T>> inputsInDepthIntersection(Node<T>? other) {
+    var l2 = other?.inputsInDepth();
+    if (l2 == null || l2.isEmpty) return [];
+
+    var l1 = inputsInDepth();
+    return l1.intersection(l2);
   }
 
   /// Returns `true` if [target] is an input in the [shortestPathToRoot].
@@ -837,48 +1017,49 @@ class Node<T> extends NodeIO<T> {
       [this]
     ];
 
-    final processedNodes = <Node<T>>{};
-    final queue = ListQueue<Node<T>>()..add(this);
-
     final computingPathsIdxRet = <int>[0];
     var expandCursor = 0;
 
-    while (queue.isNotEmpty) {
-      var node = queue.removeFirst();
+    var shortestPath = GraphWalker<T>().walkByNodes<List<Node<T>>>(
+      [this],
+      outputsProvider: (step, node) {
+        var inputs = node._inputs;
+        return inputs.isEmpty ? [] : [inputs.first];
+      },
+      process: (step) {
+        var node = step.node;
 
-      var computingPaths = _getComputingPaths(
-          computingPathsBuffer, node, expandCursor, computingPathsIdxRet);
+        var computingPaths = _getComputingPaths<T>(
+            computingPathsBuffer, node, expandCursor, computingPathsIdxRet);
 
-      if (computingPaths == null) continue;
+        if (computingPaths == null) return null;
 
-      var computingPathsIdx = computingPathsIdxRet[0];
+        var computingPathsIdx = computingPathsIdxRet[0];
 
-      if (node.isRoot) {
-        // [computingPaths] of [node] completed.
-        // Return one of the shortest path (1st):
-        return computingPaths.first;
-      }
+        if (node.isRoot) {
+          // [computingPaths] of [node] completed.
+          // Return one of the shortest path (1st):
+          return computingPaths.first;
+        }
 
-      var newNode = processedNodes.add(node);
-      if (!newNode) {
-        // Only computing the shortest branch:
-        continue;
-      }
+        // In a BFS the 1st input will be one of the closest to root,
+        // don't need to expand with all the inputs:
+        var closerToRoot = node._inputs.first;
 
-      var inputs = node._inputs;
+        var inputs = [closerToRoot];
 
-      // In a BFS the 1st input will be one of the closest to root,
-      // don't need to expand with all the inputs:
-      var closerToRoot = inputs.first;
-      inputs = [closerToRoot];
+        expandCursor = _expandComputingPaths<T>(computingPathsBuffer,
+            computingPaths, computingPathsIdx, inputs, expandCursor);
 
-      expandCursor = _expandComputingPaths(computingPathsBuffer, computingPaths,
-          computingPathsIdx, inputs, expandCursor);
+        return null;
+      },
+    );
 
-      queue.add(closerToRoot);
+    if (shortestPath == null) {
+      throw StateError("No path to root from: $value");
     }
 
-    throw StateError("No path to root.");
+    return shortestPath;
   }
 
   /// Resolves all the paths to the root from this node.
@@ -893,81 +1074,79 @@ class Node<T> extends NodeIO<T> {
       [this]
     ];
 
-    // Count the number of times that a node was processed:
-    final processedNodesCounter = <Node<T>, int>{};
-
-    final queue = ListQueue<Node<T>>()..add(this);
-
     final computingPathsIdxRet = <int>[0];
     var expandCursor = 0;
 
-    while (queue.isNotEmpty) {
-      var node = queue.removeFirst();
+    GraphWalker<T>(
+      maxExpansion: 3,
+    ).walkByNodes<List<Node<T>>>(
+      [this],
+      outputsProvider: (step, node) => node._inputs,
+      process: (step) {
+        var node = step.node;
 
-      var computingPaths = _getComputingPaths(
-          computingPathsBuffer, node, expandCursor, computingPathsIdxRet);
+        var computingPaths = _getComputingPaths<T>(
+            computingPathsBuffer, node, expandCursor, computingPathsIdxRet);
 
-      if (computingPaths == null) continue;
+        if (computingPaths == null) return null;
 
-      var computingPathsIdx = computingPathsIdxRet[0];
-      var computingPathsEndIdx = computingPathsIdx + computingPaths.length;
+        var computingPathsIdx = computingPathsIdxRet[0];
+        var computingPathsEndIdx = computingPathsIdx + computingPaths.length;
 
-      if (node.isRoot) {
-        // [computingPaths] of [node] completed,
-        // remove it from [computingPathsBuffer].
-        computingPathsBuffer.removeRange(
-            computingPathsIdx, computingPathsEndIdx);
+        if (node.isRoot) {
+          // [computingPaths] of [node] completed,
+          // remove it from [computingPathsBuffer].
+          computingPathsBuffer.removeRange(
+              computingPathsIdx, computingPathsEndIdx);
 
-        rootPaths.addAll(computingPaths);
-        expandCursor = computingPathsIdx;
+          rootPaths.addAll(computingPaths);
+          expandCursor = computingPathsIdx;
 
-        // Allow independent branches to be computed:
-        processedNodesCounter[node] = 0;
-        continue;
-      }
-
-      // Increment the processed node counter for [node]:
-      final nodeProcessCount =
-          processedNodesCounter.update(node, (c) => c + 1, ifAbsent: () => 1);
-
-      final newNode = nodeProcessCount == 1;
-
-      // Skip target nodes (leafs with `target == true`)
-      // already processed (avoids self-reference):
-      if (node.isTarget && !newNode) {
-        continue;
-      }
-
-      var inputs = node._inputs;
-
-      if (!newNode) {
-        var unprocessed =
-            inputs.where((e) => !processedNodesCounter.containsKey(e)).toList();
-
-        // Not all inputs are unprocessed:
-        if (unprocessed.length < inputs.length) {
-          // Allow inputs that are not targets (leaves with `matches`)
-          // or that are [unprocessed].
-          var allowedIts =
-              inputs.where((e) => !e.isTarget || unprocessed.contains(e));
-
-          // Ensure that inputs processed more than 3 times are skipped,
-          // to avoid infinite loops or meaningless branches already seen:
-          allowedIts =
-              allowedIts.where((e) => (processedNodesCounter[e] ?? 0) <= 3);
-
-          var allowed = allowedIts.toList();
-
-          // Only expand with allowed inputs:
-          inputs = allowed;
+          // Allow independent branches to be computed:
+          // Reset counter to 0:
+          return 0;
         }
-      }
 
-      expandCursor = _expandComputingPaths(computingPathsBuffer, computingPaths,
-          computingPathsIdx, inputs, expandCursor);
+        final processed = step.processed;
 
-      queue.addAll(inputs);
-    }
+        final newNode = processed[node] == 1;
+
+        // Skip target nodes (leafs with `target == true`)
+        // already processed (avoids self-reference):
+        if (node.isTarget && !newNode) {
+          return null;
+        }
+
+        var inputs = node._inputs;
+
+        if (!newNode) {
+          var unprocessed =
+              inputs.where((e) => !processed.containsKey(e)).toList();
+
+          // Not all inputs are unprocessed:
+          if (unprocessed.length < inputs.length) {
+            // Allow inputs that are not targets (leaves with `matches`)
+            // or that are [unprocessed].
+            var allowedIts =
+                inputs.where((e) => !e.isTarget || unprocessed.contains(e));
+
+            // Ensure that inputs processed more than 3 times are skipped,
+            // to avoid infinite loops or meaningless branches already seen:
+            allowedIts = allowedIts.where((e) => (processed[e] ?? 0) <= 3);
+
+            var allowed = allowedIts.toList();
+
+            // Only expand with allowed inputs:
+            inputs = allowed;
+          }
+        }
+
+        expandCursor = _expandComputingPaths(computingPathsBuffer,
+            computingPaths, computingPathsIdx, inputs, expandCursor);
+
+        return null;
+      },
+    );
 
     return rootPaths;
   }
@@ -981,7 +1160,7 @@ class Node<T> extends NodeIO<T> {
   ///   the [node] computing paths should be. See [_expandComputingPaths].
   /// - The [node[ computing paths are the ones where the 1st element is [node].
   // Change `computingPathIdx` to records when moving to Dart 3:
-  List<List<Node<T>>>? _getComputingPaths(
+  static List<List<Node<T>>>? _getComputingPaths<T>(
       List<List<Node<T>>> computingPathsBuffer,
       Node node,
       int expandCursor,
@@ -1008,7 +1187,7 @@ class Node<T> extends NodeIO<T> {
 
   /// Expands the computing paths of [node],
   /// [computingPathsBuffer]
-  int _expandComputingPaths(
+  static int _expandComputingPaths<T>(
       List<List<Node<T>>> computingPathsBuffer,
       List<List<Node<T>>> computingPaths,
       int computingPathsIdx,
@@ -1038,9 +1217,11 @@ class Node<T> extends NodeIO<T> {
   }
 
   /// Resets this node for a path scan.
+  /// Clears [_target] and [attachment].
   @override
   void reset() {
     _target = false;
+    attachment = null;
   }
 
   @override
@@ -1070,15 +1251,150 @@ class Node<T> extends NodeIO<T> {
 }
 
 extension IterableNodeExtension<T> on Iterable<Node<T>> {
-  List<T> toListOfValues() => map((e) => e.value).toList();
+  Iterable<T> toIterableOfValues() => map((e) => e.value);
 
-  List<String> toListOfString() => map((e) => e.value.toString()).toList();
+  Iterable<String> toIterableOfString() => map((e) => e.value.toString());
+
+  List<T> toListOfValues() => toIterableOfValues().toList();
+
+  List<String> toListOfString() => toIterableOfString().toList();
 
   /// Dispose the graph of all the [Node]s.
   void disposeGraph() {
     for (var e in this) {
       e.disposeGraph();
     }
+  }
+
+  List<Node<T>> intersection(List<Node<T>> other) {
+    if (identical(this, other)) return toList();
+    if (isEmpty || other.isEmpty) return [];
+
+    var intersection = where((e) => other.contains(e)).toList();
+    return intersection;
+  }
+
+  Map<Node<T>, List<Node<T>>> outputsInDepth({bool bfs = false}) =>
+      Map<Node<T>, List<Node<T>>>.fromEntries(
+          map((e) => MapEntry(e, e.outputsInDepth(bfs: bfs))));
+
+  Map<Node<T>, List<Node<T>>> inputsInDepth({bool bfs = false}) =>
+      Map<Node<T>, List<Node<T>>>.fromEntries(
+          map((e) => MapEntry(e, e.inputsInDepth(bfs: bfs))));
+
+  List<Node<T>> outputsInDepthIntersection({bool bfs = false}) {
+    var intersection = outputsInDepth(bfs: bfs)
+        .values
+        .reduce((intersection, l) => intersection.intersection(l));
+    return intersection;
+  }
+
+  List<Node<T>> inputsInDepthIntersection({bool bfs = false}) {
+    var intersection = inputsInDepth(bfs: bfs)
+        .values
+        .reduce((intersection, l) => intersection.intersection(l));
+    return intersection;
+  }
+
+  List<Node<T>> sortedByOutputsDepth({bool bfs = false}) {
+    var nodesOutputs = outputsInDepth(bfs: bfs);
+
+    var entries = nodesOutputs.entries.toList();
+
+    entries.sort((a, b) => a.value.length.compareTo(b.value.length));
+
+    var nodes = entries.map((e) => e.key).toList();
+    return nodes;
+  }
+
+  List<Node<T>> sortedByInputDepth({bool bfs = false}) {
+    var nodesInputs = inputsInDepth(bfs: bfs);
+
+    var entries = nodesInputs.entries.toList();
+
+    entries.sort((a, b) => a.value.length.compareTo(b.value.length));
+
+    var nodes = entries.map((e) => e.key).toList();
+    return nodes;
+  }
+
+  List<Node<T>> sortedByOutputDependency({bool bfs = false}) {
+    var nodesOutputs = outputsInDepth(bfs: bfs);
+
+    var entries = nodesOutputs.entries.toList();
+
+    var alone =
+        entries.where((e) => e.value.isEmpty).map((e) => e.key).toList();
+    entries.removeWhere((e) => alone.contains(e.key));
+
+    alone = alone.sortedByInputDepth();
+
+    var entriesIntersections = entries.map((e1) {
+      var nodes1 = e1.value;
+      var others = entries.where((e2) => e2 != e1);
+
+      var intersections = others
+          .map((other) => MapEntry(other.key, nodes1.intersection(other.value)))
+          .where((e) => e.value.isNotEmpty)
+          .toList();
+
+      return MapEntry(e1.key, Map.fromEntries(intersections));
+    }).toList();
+
+    var isolated = entriesIntersections
+        .where((e) => e.value.isEmpty)
+        .map((e) => e.key)
+        .toList();
+
+    entriesIntersections.removeWhere((e) => isolated.contains(e.key));
+    entries.removeWhere((e) => isolated.contains(e.key));
+
+    isolated = isolated.sortedByInputDepth();
+
+    var rest = entries.map((e) => e.key).sortedByInputDepth();
+
+    var nodes = [...alone, ...isolated, ...rest].toList();
+    return nodes;
+  }
+
+  List<Node<T>> sortedByInputDependency({bool bfs = false}) {
+    var nodesInputs = inputsInDepth(bfs: bfs);
+
+    var entries = nodesInputs.entries.toList();
+
+    var alone =
+        entries.where((e) => e.value.isEmpty).map((e) => e.key).toList();
+    entries.removeWhere((e) => alone.contains(e.key));
+
+    alone = alone.sortedByOutputsDepth().toReversedList();
+
+    var entriesIntersections = entries.map((e1) {
+      var nodes1 = e1.value;
+      var others = entries.where((e2) => e2 != e1);
+
+      var intersections = others
+          .map((other) => MapEntry(other.key, nodes1.intersection(other.value)))
+          .where((e) => e.value.isNotEmpty)
+          .toList();
+
+      return MapEntry(e1.key, Map.fromEntries(intersections));
+    }).toList();
+
+    var isolated = entriesIntersections
+        .where((e) => e.value.isEmpty)
+        .map((e) => e.key)
+        .toList();
+
+    entriesIntersections.removeWhere((e) => isolated.contains(e.key));
+    entries.removeWhere((e) => isolated.contains(e.key));
+
+    isolated = isolated.sortedByOutputsDepth().toReversedList();
+
+    var rest =
+        entries.map((e) => e.key).sortedByOutputsDepth().toReversedList();
+
+    var nodes = [...alone, ...isolated, ...rest].toList();
+    return nodes;
   }
 }
 
@@ -1153,5 +1469,5 @@ extension IterableOfListNodeExtension<T> on Iterable<List<Node<T>>> {
 }
 
 extension _ListTypeExtension<T> on List<T> {
-  Type get genericType => T;
+  List<T> toReversedList() => reversed.toList();
 }

--- a/lib/src/graph_explorer_base.dart
+++ b/lib/src/graph_explorer_base.dart
@@ -333,7 +333,6 @@ class Graph<T> implements NodeIO<T> {
           if (jsonNode != null && (jsonNode is! Map && jsonNode is! String)) {
             throw StateError("Invalid node type> $nodeValue: $jsonNode");
           }
-
           node.attachment = jsonNode;
         } else if (!identical(jsonNode, nodeAttachment)) {
           if (jsonNode is Map) {
@@ -347,7 +346,7 @@ class Graph<T> implements NodeIO<T> {
               throw StateError(
                   "Invalid node reference: $nodeValue -> $jsonNode");
             }
-          } else {
+          } else if (jsonNode != null) {
             throw StateError(
                 "Invalid node type (graph)> $nodeValue: $jsonNode");
           }

--- a/lib/src/graph_explorer_base.dart
+++ b/lib/src/graph_explorer_base.dart
@@ -773,7 +773,7 @@ class Graph<T> implements NodeIO<T> {
         from.toList(),
         nodeProvider: (step, nodeValue) => getNode(nodeValue),
         outputsProvider: (step, node) => node._outputs,
-        expandSideRoots: expandSideRoots,
+        expandSideBranches: expandSideRoots,
       );
 
   /// Walk the graph nodes outputs starting [from] and stopping at [stopMatcher] (if provided).

--- a/lib/src/graph_explorer_walker.dart
+++ b/lib/src/graph_explorer_walker.dart
@@ -1,0 +1,611 @@
+// Copyright (c) 2023, Graciliano M P. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Author:
+// - Graciliano M. Passos: gmpassos @ GitHub
+//
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'graph_explorer_base.dart';
+
+/// A [GraphWalker] step context.
+abstract class GraphStep<T> {
+  GraphWalker<T> get walker;
+
+  /// The table of processed [Node]s
+  Map<Node<T>, int> get processed => walker.processedNodes;
+
+  /// The previous step.
+  GraphStep<T>? get previous;
+
+  /// This step depth.
+  int get depth;
+
+  /// The parent step node value.
+  T? get parentValue;
+
+  /// The step node value.
+  T get nodeValue;
+
+  /// Returns `true` if this step is a root step.
+  /// - Does NOT mean that this step node is root ([Node.isRoot]).
+  bool get isRoot => previous == null;
+
+  /// NOT [isRoot].
+  bool get isNotRoot => previous != null;
+
+  List<T>? _valuePathToRoot;
+
+  /// The values path to the root step.
+  List<T> get valuePathToRoot => _valuePathToRoot ??= _valuePathToRootImpl();
+
+  List<T> _valuePathToRootImpl() {
+    final previousPath = previous?._valuePathToRoot;
+    if (previousPath != null) {
+      return [...previousPath, nodeValue];
+    }
+
+    List<T> path = [];
+
+    GraphStep<T>? step = this;
+    while (step != null) {
+      path.add(step.nodeValue);
+      step = step.previous;
+    }
+
+    return path.toReversedList();
+  }
+
+  /// Same as [valuePathToRoot], but with additional [head] and [tail].
+  List<T> valuePathToRootWith({Iterable<T>? head, Iterable<T>? tail}) {
+    final valuePathToRoot = this.valuePathToRoot;
+
+    if (head != null || tail != null) {
+      return [...?head, ...valuePathToRoot, ...?tail];
+    } else {
+      return valuePathToRoot;
+    }
+  }
+
+  /// Returns a [String] that represents a full path to the root step.
+  String fullPathToRoot(
+      {String pathDelimiter = '/',
+      Iterable<T>? head,
+      Iterable<T>? tail,
+      Iterable<String>? headString,
+      Iterable<String>? tailString}) {
+    var pathToRoot =
+        valuePathToRootWith(head: head, tail: tail).map((e) => e.toString());
+    if (headString != null || tailString != null) {
+      pathToRoot = [...?headString, ...pathToRoot, ...?tailString];
+    }
+    return pathToRoot.join(pathDelimiter);
+  }
+
+  @override
+  String toString() {
+    final previous = this.previous;
+    return 'GraphStep[$depth]{ ${previous != null ? '${previous.isNotRoot ? '...' : ''}${previous.nodeValue} -> ' : ''}$nodeValue }';
+  }
+}
+
+/// A [GraphStep] that has only the node value,
+/// but without a resolved [Node] yet.
+/// See [Graph.populate].
+class GraphValueStep<T> extends GraphStep<T> {
+  @override
+  final GraphWalker<T> walker;
+
+  @override
+  final GraphStep<T>? previous;
+  @override
+  final int depth;
+
+  @override
+  final T nodeValue;
+
+  GraphValueStep(this.walker, this.previous, this.nodeValue)
+      : depth = previous != null ? previous.depth + 1 : 0;
+
+  @override
+  T? get parentValue => previous?.nodeValue;
+}
+
+/// A [GraphStep] with a [Node] resolved.
+class GraphNodeStep<T> extends GraphStep<T> {
+  @override
+  final GraphWalker<T> walker;
+
+  @override
+  final GraphNodeStep<T>? previous;
+  @override
+  final int depth;
+
+  /// The node of this step.
+  final Node<T> node;
+
+  GraphNodeStep(this.walker, this.previous, this.node)
+      : depth = previous != null ? previous.depth + 1 : 0;
+
+  /// The [Node] of the [previous] step.
+  Node<T>? get parentNode => previous?.node;
+
+  @override
+  T? get parentValue => parentNode?.value;
+
+  @override
+  T get nodeValue => node.value;
+
+  List<Node<T>>? _nodePathToRoot;
+
+  List<Node<T>> get nodePathToRoot => _nodePathToRoot ??= _nodePathToRootImpl();
+
+  List<Node<T>> _nodePathToRootImpl() {
+    final previousPath = previous?._nodePathToRoot;
+    if (previousPath != null) {
+      return [...previousPath, node];
+    }
+
+    List<Node<T>> path = [];
+
+    GraphNodeStep<T>? step = this;
+    while (step != null) {
+      path.add(step.node);
+      step = step.previous;
+    }
+
+    return path.toReversedList();
+  }
+}
+
+typedef GraphWalkNodeProvider<T> = Node<T>? Function(
+    GraphStep<T> step, T nodeValue);
+
+typedef GraphWalkNodeProcessor<T> = dynamic Function(GraphNodeStep<T> step);
+
+typedef GraphWalkNodeOutputsProvider<T> = Iterable<Node<T>>? Function(
+    GraphNodeStep<T> step, Node<T> node);
+
+typedef GraphWalkNodeOutputsProviderAsync<T> = FutureOr<Iterable<Node<T>>?>
+    Function(GraphNodeStep<T> step, Node<T> node);
+
+typedef GraphWalkOutputsProvider<T> = Iterable<T>? Function(
+    GraphNodeStep<T> step, T nodeValue);
+
+typedef GraphWalkOutputsProviderAsync<T> = FutureOr<Iterable<T>?> Function(
+    GraphNodeStep<T> step, T nodeValue);
+
+enum GraphWalking {
+  stop,
+  next,
+}
+
+/// [Graph] walker algorithms.
+class GraphWalker<T> {
+  /// The [NodeMatcher] used to stop the walking.
+  final NodeMatcher<T> stopMatcher;
+
+  /// If `true` will process root nodes.
+  final bool processRoots;
+
+  /// The maximum expansions that a node can have. Default: 1
+  final int maxExpansion;
+
+  /// If `true` will perform a BFS (Breadth-First Search), if `false` an DFS (Depth-First Search).
+  /// Default: `false` (DFS).
+  final bool bfs;
+
+  final Map<Node<T>, int>? _initialProcessedNodes;
+
+  final Map<Node<T>, int> _processedNodes = <Node<T>, int>{};
+
+  GraphWalker({
+    NodeMatcher<T>? stopMatcher,
+    this.processRoots = true,
+    this.maxExpansion = 1,
+    this.bfs = false,
+    Map<Node<T>, int>? initialProcessedNodes,
+  })  : stopMatcher = stopMatcher ?? NoneNode(),
+        _initialProcessedNodes = initialProcessedNodes {
+    reset();
+  }
+
+  late final Map<Node<T>, int> processedNodes =
+      UnmodifiableMapView(_processedNodes);
+
+  void reset({bool rollbackToInitialProcessedNodes = true}) {
+    _processedNodes.clear();
+
+    final initialProcessedNodes = _initialProcessedNodes;
+    if (rollbackToInitialProcessedNodes && initialProcessedNodes != null) {
+      _processedNodes.addAll(initialProcessedNodes);
+    }
+  }
+
+  /// A generic walk algorithm.
+  R? walk<R>(
+    Iterable<T> from, {
+    required GraphWalkNodeProvider<T> nodeProvider,
+    required GraphWalkOutputsProvider<T> outputsProvider,
+    required GraphWalkNodeProcessor<T> process,
+  }) {
+    final processed = _processedNodes;
+    final queue = ListQueue<GraphNodeStep<T>>();
+
+    for (var rootValue in from) {
+      var rootStepValue = GraphValueStep(this, null, rootValue);
+
+      final rootNode = nodeProvider(rootStepValue, rootValue) ??
+          (throw StateError("Can't find root node: $rootValue"));
+
+      var rootStep = GraphNodeStep(this, null, rootNode);
+      queue.add(rootStep);
+    }
+
+    while (queue.isNotEmpty) {
+      final step = queue.removeFirst();
+      final node = step.node;
+      final nodeValue = step.nodeValue;
+
+      var processCount = processed.increment(node);
+
+      if (processCount <= maxExpansion) {
+        if (processRoots || step.isNotRoot) {
+          var ret = process(step);
+
+          if (ret != null) {
+            if (ret is GraphWalking) {
+              switch (ret) {
+                case GraphWalking.stop:
+                  return null;
+                case GraphWalking.next:
+                  continue;
+              }
+            } else if (ret is bool) {
+              if (ret) {
+                return _resolveWalkProcessReturn<T, R>(node, ret);
+              }
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
+            }
+          }
+        }
+
+        if (stopMatcher.matchesNode(node)) {
+          return _resolveWalkProcessReturn<T, R>(node, true);
+        }
+
+        var outputs = outputsProvider(step, nodeValue);
+        if (outputs != null) {
+          var outputsNodes = outputs.map((v) {
+            var nodeStepValue = GraphValueStep(this, step, v);
+            return nodeProvider(nodeStepValue, v)!;
+          });
+
+          queue.addAllToScanQueue(outputsNodes.toGraphNodeStep(step), bfs);
+        }
+      }
+    }
+
+    return _resolveWalkProcessReturn<T, R>(null, false);
+  }
+
+  /// A generic walk algorithm.
+  Future<R?> walkAsync<R>(
+    Iterable<T> from, {
+    required GraphWalkNodeProvider<T> nodeProvider,
+    required GraphWalkOutputsProviderAsync<T> outputsProvider,
+    required GraphWalkNodeProcessor<T> process,
+  }) async {
+    final processed = _processedNodes;
+    final queue = ListQueue<GraphNodeStep<T>>();
+
+    for (var rootValue in from) {
+      var rootStepValue = GraphValueStep(this, null, rootValue);
+
+      final rootNode = nodeProvider(rootStepValue, rootValue) ??
+          (throw StateError("Can't find root node: $rootValue"));
+
+      var rootStep = GraphNodeStep(this, null, rootNode);
+      queue.add(rootStep);
+    }
+
+    while (queue.isNotEmpty) {
+      final step = queue.removeFirst();
+      final node = step.node;
+      final nodeValue = step.nodeValue;
+
+      var processCount = processed.increment(node);
+
+      if (processCount <= maxExpansion) {
+        if (processRoots || step.isNotRoot) {
+          var ret = await process(step);
+
+          if (ret != null) {
+            if (ret is GraphWalking) {
+              switch (ret) {
+                case GraphWalking.stop:
+                  return null;
+                case GraphWalking.next:
+                  continue;
+              }
+            } else if (ret is bool) {
+              if (ret) {
+                return _resolveWalkProcessReturn<T, R>(node, ret);
+              }
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
+            }
+          }
+        }
+
+        if (stopMatcher.matchesNode(node)) {
+          return _resolveWalkProcessReturn<T, R>(node, true);
+        }
+
+        var outputs = await outputsProvider(step, nodeValue);
+        if (outputs != null) {
+          var outputsNodes = outputs.map((v) {
+            var nodeStepValue = GraphValueStep(this, step, v);
+            return nodeProvider(nodeStepValue, v)!;
+          });
+
+          queue.addAllToScanQueue(outputsNodes.toGraphNodeStep(step), bfs);
+        }
+      }
+    }
+
+    return _resolveWalkProcessReturn<T, R>(null, false);
+  }
+
+  /// A generic walk algorithm using [Node]s.
+  R? walkByNodes<R>(
+    Iterable<Node<T>> from, {
+    required GraphWalkNodeOutputsProvider<T> outputsProvider,
+    required GraphWalkNodeProcessor<T> process,
+  }) {
+    final processed = _processedNodes;
+    final queue = ListQueue<GraphNodeStep<T>>();
+
+    for (var rootNode in from) {
+      var rootStep = GraphNodeStep(this, null, rootNode);
+      queue.add(rootStep);
+    }
+
+    while (queue.isNotEmpty) {
+      final step = queue.removeFirst();
+      final node = step.node;
+
+      var processCount = processed.increment(node);
+
+      if (processCount <= maxExpansion) {
+        if (processRoots || step.isNotRoot) {
+          var ret = process(step);
+
+          if (ret != null) {
+            if (ret is GraphWalking) {
+              switch (ret) {
+                case GraphWalking.stop:
+                  return null;
+                case GraphWalking.next:
+                  continue;
+              }
+            } else if (ret is bool) {
+              if (ret) {
+                return _resolveWalkProcessReturn<T, R>(node, ret);
+              }
+            } else if (ret is int) {
+              processed[node] = ret;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
+            }
+          }
+        }
+
+        if (stopMatcher.matchesNode(node)) {
+          return _resolveWalkProcessReturn<T, R>(node, true);
+        }
+
+        var outputs = outputsProvider(step, node);
+        if (outputs != null) {
+          queue.addAllToScanQueue(outputs.toGraphNodeStep(step), bfs);
+        }
+      }
+    }
+
+    return _resolveWalkProcessReturn<T, R>(null, false);
+  }
+
+  /// A generic walk algorithm using [Node]s.
+  Future<R?> walkByNodesAsync<R>(
+    Iterable<Node<T>> from, {
+    required GraphWalkNodeOutputsProviderAsync<T> outputsProvider,
+    required GraphWalkNodeProcessor<T> process,
+  }) async {
+    final processed = _processedNodes;
+    final queue = ListQueue<GraphNodeStep<T>>();
+
+    for (var rootNode in from) {
+      var rootStep = GraphNodeStep(this, null, rootNode);
+      queue.add(rootStep);
+    }
+
+    while (queue.isNotEmpty) {
+      final step = queue.removeFirst();
+      final node = step.node;
+
+      var processCount = processed.increment(node);
+
+      if (processCount <= maxExpansion) {
+        if (processRoots || step.isNotRoot) {
+          var ret = await process(step);
+
+          if (ret != null) {
+            if (ret is GraphWalking) {
+              switch (ret) {
+                case GraphWalking.stop:
+                  return null;
+                case GraphWalking.next:
+                  continue;
+              }
+            } else if (ret is bool) {
+              if (ret) {
+                return _resolveWalkProcessReturn<T, R>(node, ret);
+              }
+            } else if (ret is int) {
+              processed[node] = ret;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
+            }
+          }
+        }
+
+        if (stopMatcher.matchesNode(node)) {
+          return _resolveWalkProcessReturn<T, R>(node, true);
+        }
+
+        var outputs = await outputsProvider(step, node);
+        if (outputs != null) {
+          queue.addAllToScanQueue(outputs.toGraphNodeStep(step), bfs);
+        }
+      }
+    }
+
+    return _resolveWalkProcessReturn<T, R>(null, false);
+  }
+
+  static R? _resolveWalkProcessReturn<T, R>(Node<T>? node, Object? o) {
+    if (R == bool) {
+      if (o is R) return o;
+      return null;
+    }
+
+    if (o is R) {
+      return o;
+    }
+
+    if (node is R) {
+      return node as R;
+    }
+
+    return null;
+  }
+
+  /// Returns a [Map] representation of this graph from [roots].
+  Map<K, dynamic> toTreeFrom<K>(
+    List<T> roots, {
+    required GraphWalkNodeProvider<T> nodeProvider,
+    required GraphWalkNodeOutputsProvider<T> outputsProvider,
+    K Function(GraphStep<T> step, T value)? keyCast,
+  }) {
+    final processed = _processedNodes;
+
+    if (keyCast == null) {
+      if (K == String) {
+        keyCast = (s, v) => v.toString() as K;
+      } else if (K == Node || K == <Node<T>>[].genericType) {
+        keyCast = (s, v) => nodeProvider(s, v) as K;
+      } else {
+        keyCast = (s, v) => v as K;
+      }
+    }
+
+    Map<K, dynamic> Function() createNode = K == dynamic
+        ? () => (<T, dynamic>{} as Map<K, dynamic>)
+        : () => <K, dynamic>{};
+
+    Map<Node<T>, Map<K, dynamic>> allTreeNodes = K == dynamic
+        ? (<Node<T>, Map<T, dynamic>>{} as Map<Node<T>, Map<K, dynamic>>)
+        : <Node<T>, Map<K, dynamic>>{};
+
+    Map<K, dynamic> tree =
+        K == dynamic ? (<T, dynamic>{} as Map<K, dynamic>) : <K, dynamic>{};
+
+    var rootNodes = roots.map((e) {
+      var rootStep = GraphValueStep(this, null, e);
+      return nodeProvider(rootStep, e) ??
+          (throw ArgumentError("Root not present in graph: $e"));
+    }).toList();
+
+    rootNodes = rootNodes.sortedByInputDependency();
+
+    final queue = ListQueue<GraphNodeStep<T>>();
+
+    queue.addAll(rootNodes.toGraphRootStep(this));
+
+    while (queue.isNotEmpty) {
+      final step = queue.removeFirst();
+      final node = step.node;
+
+      var processedCount = processed.increment(node);
+
+      var nodeKey = keyCast(step, node.value);
+
+      if (processedCount <= 1) {
+        var parentNode = step.parentNode;
+        var parentTreeNode =
+            parentNode != null ? allTreeNodes[parentNode]! : tree;
+
+        var treeNode = allTreeNodes[node];
+        if (treeNode == null) {
+          treeNode = allTreeNodes[node] = createNode();
+          parentTreeNode[nodeKey] = node.outputs.isEmpty ? null : treeNode;
+        } else {
+          parentTreeNode[nodeKey] = nodeKey;
+        }
+
+        var outputs = outputsProvider(step, node);
+
+        if (outputs != null) {
+          queue.addAllToScanQueue(outputs.toGraphNodeStep(step), bfs);
+        }
+      } else {
+        var parentNode = step.parentNode;
+        var parentTreeNode =
+            parentNode != null ? allTreeNodes[parentNode]! : tree;
+
+        var treeNode = allTreeNodes[node];
+        assert(treeNode != null);
+        parentTreeNode[nodeKey] = nodeKey;
+      }
+    }
+
+    return tree;
+  }
+}
+
+extension _ToGraphNodeStepIterableExtension<T> on Iterable<Node<T>> {
+  Iterable<GraphNodeStep<T>> toGraphNodeStep(GraphNodeStep<T> previous) =>
+      map((node) => GraphNodeStep<T>(previous.walker, previous, node));
+
+  Iterable<GraphNodeStep<T>> toGraphRootStep(GraphWalker<T> walker) =>
+      map((node) => GraphNodeStep<T>(walker, null, node));
+}
+
+extension _MapOfIntExtension<K> on Map<K, int> {
+  int increment(K key) => update(key, (count) => count + 1, ifAbsent: () => 1);
+}
+
+extension _ListTypeExtension<T> on List<T> {
+  Type get genericType => T;
+
+  List<T> toReversedList() => reversed.toList();
+}
+
+extension _ListQueueExtension<T> on ListQueue<T> {
+  void addAllToScanQueue(Iterable<T> elements, bool bfs) {
+    if (bfs) {
+      addAll(elements);
+    } else {
+      var reversed = elements is List<T>
+          ? elements.reversed
+          : elements.toList(growable: false).reversed;
+      for (var e in reversed) {
+        addFirst(e);
+      }
+    }
+  }
+}

--- a/lib/src/graph_explorer_walker.dart
+++ b/lib/src/graph_explorer_walker.dart
@@ -618,7 +618,7 @@ class GraphWalker<T> {
   }
 
   /// Returns the walk order of nodes.
-  List<Node<T>> walkOrder<K>(
+  List<Node<T>> walkOrder(
     List<T> roots, {
     required GraphWalkNodeProvider<T> nodeProvider,
     required GraphWalkNodeOutputsProvider<T> outputsProvider,

--- a/lib/src/graph_explorer_walker.dart
+++ b/lib/src/graph_explorer_walker.dart
@@ -309,6 +309,8 @@ class GraphWalker<T> {
               }
             } else if (ret is GraphWalkingInstructionSetExpansionCounter) {
               processed[node] = ret.count;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
             }
           }
         }
@@ -375,6 +377,8 @@ class GraphWalker<T> {
               }
             } else if (ret is GraphWalkingInstructionSetExpansionCounter) {
               processed[node] = ret.count;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
             }
           }
         }
@@ -435,6 +439,8 @@ class GraphWalker<T> {
               }
             } else if (ret is GraphWalkingInstructionSetExpansionCounter) {
               processed[node] = ret.count;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
             }
           }
         }
@@ -489,6 +495,8 @@ class GraphWalker<T> {
               }
             } else if (ret is GraphWalkingInstructionSetExpansionCounter) {
               processed[node] = ret.count;
+            } else {
+              return _resolveWalkProcessReturn<T, R>(node, ret);
             }
           }
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,12 @@
 name: graph_explorer
 description: A versatile library for generating and analyzing graphs with support for JSON and ASCIIArtTree.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/gmpassos/graph_explorer
 
 environment:
   sdk: '>=2.14.0 <4.0.0'
 
 dependencies:
-  ascii_art_tree: ^1.0.5
   collection: ^1.17.0
 
 dev_dependencies:
@@ -15,7 +14,3 @@ dev_dependencies:
   dependency_validator: ^3.2.2
   test: ^1.21.4
   coverage: ^1.2.0
-
-#dependency_overrides:
-#  ascii_art_tree:
-#    path: ../ascii_art_tree


### PR DESCRIPTION
- Added `AnyNode` and `NoneNode`.
- `Graph`:
  - Added `populate` and `populateAsync`.
  - Added `walkOutputsFrom` and `walkInputsFrom`.
  - Added `rootValues`, `valuesToNodes`.
- `Node`:
  - Added field `attachment`.
- New `GraphWalker`.

- Removed `ascii_art_tree` dependency:
  - Package `ascii_art_tree 1.0.6` now uses `graph_explorer` internally (avoid dependency loop). - The `Graph` integration was moved to package `ascii_art_tree` as an extension.